### PR TITLE
HE-546: Fix previous and next button not working on iphone XS MAX devices

### DIFF
--- a/SKPhotoBrowser/SKToolbar.swift
+++ b/SKPhotoBrowser/SKToolbar.swift
@@ -31,6 +31,15 @@ class SKToolbar: UIToolbar {
         setupApperance()
         setupToolbar()
     }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if let view = super.hitTest(point, with: event) {
+            if SKMesurement.screenWidth - point.x < 50 { 
+                return view
+            }
+        }
+        return nil
+    }
 }
 
 private extension SKToolbar {


### PR DESCRIPTION
This quick fix is added to version 6.0.0 but not included to 5.1.0. 
I will update commit hash of my babble-iOs PR once this is merged to 5.1.0 branch. 

Let me know if you have any questions or suggestions.